### PR TITLE
Modernize packaging and NumPy usage

### DIFF
--- a/data/chalearn/analyze.py
+++ b/data/chalearn/analyze.py
@@ -22,10 +22,10 @@ data_path = os.path.join("data", "chalearn", "small", "network1_oopsi.pkl.gz")
 
 with gzip.open(data_path, 'r') as f:
     P, F, Cf, network, pos = pickle.load(f)
-    S_full = (P > 0.1).astype(np.int)
+    S_full = (P > 0.1).astype(np.int64)
 
 # Cast to int
-S_full = S_full.astype(np.int)
+S_full = S_full.astype(np.int64)
 
 # Train on all but the last ten minutes (20ms time bins = 50Hz)
 T_test = 10 * 60 * 50

--- a/data/chalearn/cluster.py
+++ b/data/chalearn/cluster.py
@@ -14,7 +14,7 @@ data_path = os.path.join("data", "chalearn", "small", "network6_oopsi.pkl.gz")
 
 with gzip.open(data_path, 'r') as f:
     P, F, Cf, network, pos = pickle.load(f)
-    S_full = (P > 0.1).astype(np.int)
+    S_full = (P > 0.1).astype(np.int64)
 
 sbm = StochasticBlockModel(K=100, C=5)
 

--- a/data/chalearn/make_figure.py
+++ b/data/chalearn/make_figure.py
@@ -56,6 +56,6 @@ data_path = os.path.join("data", "chalearn", "small", "network1_oopsi.pkl.gz")
 
 with gzip.open(data_path, 'r') as f:
     P, F, Cf, network, pos = pickle.load(f)
-    S_full = (P > 0.1).astype(np.int)
+    S_full = (P > 0.1).astype(np.int64)
 
 make_figure_a(S_full, F, Cf)

--- a/data/chalearn/preprocess.py
+++ b/data/chalearn/preprocess.py
@@ -112,9 +112,9 @@ def parse_fluorescence_file(filename, K, delimiter=','):
                 line = line.rstrip().split(delimiter)
                 assert len(line) == K, "Line is not of length %d!" % K
                 for item in line:
-                    yield np.float(item)
+                    yield float(item)
 
-    F = np.fromiter(iter_func(), dtype=np.float)
+    F = np.fromiter(iter_func(), dtype=float)
     F = F.reshape((-1, K))
     return F
 
@@ -260,7 +260,7 @@ def discretize_fluorescence(F,
     assert np.all(D >= 0) and np.all(D < nbins), "Error in digitizing!"
 
     # Cast D to an integer matrix
-    D = D.astype(np.int)
+    D = D.astype(np.int64)
 
     return D, edges
 

--- a/data/chicago/parse_data.py
+++ b/data/chicago/parse_data.py
@@ -105,7 +105,7 @@ def dataframe_to_mat(df):
     #locations = np.unique(df.location.values)
     #K = len(locations)
     K = 77
-    C = np.zeros(N, dtype=np.int)
+    C = np.zeros(N, dtype=np.int64)
     Ns = np.zeros(K)
     for k in np.arange(K):
         #ks = df.location.values==locations[k] 

--- a/data/synthetic/generate_synthetic_data.py
+++ b/data/synthetic/generate_synthetic_data.py
@@ -81,7 +81,7 @@ def generate_synthetic_data(seed=None):
     p = 0.08
     kappa = 3.0
     v = kappa * 5.0
-    c = np.zeros(K, dtype=np.int)
+    c = np.zeros(K, dtype=np.int64)
 
     # Large network:
     # Seed = 2467634490

--- a/examples/inference/standard_gd_demo.py
+++ b/examples/inference/standard_gd_demo.py
@@ -27,7 +27,7 @@ def demo(seed=None):
     p = 0.8 * np.eye(C)
     v = 10.0 * np.eye(C) + 20.0 * (1-np.eye(C))
     # m = 0.5 * np.ones(C)
-    c = (0.0 * (np.arange(K) < 10) + 1.0 * (np.arange(K)  >= 10)).astype(np.int)
+    c = (0.0 * (np.arange(K) < 10) + 1.0 * (np.arange(K)  >= 10)).astype(np.int64)
     true_model = DiscreteTimeNetworkHawkesModelSpikeAndSlab(C=C, K=K, dt=dt, B=B, c=c, p=p, v=v)
 
     # Plot the true network

--- a/examples/inference/standard_sgd_demo.py
+++ b/examples/inference/standard_sgd_demo.py
@@ -8,7 +8,7 @@ def sample_from_network_hawkes(C, K, T, dt, B):
     # Create a true model
     p = 0.8 * np.eye(C)
     v = 10.0 * np.eye(C) + 20.0 * (1-np.eye(C))
-    c = (0.0 * (np.arange(K) < 10) + 1.0 * (np.arange(K)  >= 10)).astype(np.int)
+    c = (0.0 * (np.arange(K) < 10) + 1.0 * (np.arange(K)  >= 10)).astype(np.int64)
     true_model = DiscreteTimeNetworkHawkesModelSpikeAndSlab(C=C, K=K, dt=dt, B=B, c=c, p=p, v=v)
 
     # Plot the true network

--- a/pyhawkes/internals/bias.py
+++ b/pyhawkes/internals/bias.py
@@ -106,7 +106,7 @@ class GammaBias(GibbsSampling, MeanField, MeanFieldSVI):
         self.mf_update_lambda0(data, minibatchfrac=minibatchfrac, stepsize=stepsize)
 
     def get_vlb(self):
-        """
+        r"""
         Variational lower bound for \lambda_k^0
         E[LN p(\lambda_k^0 | \alpha, \beta)] -
         E[LN q(\lambda_k^0 | \tilde{\alpha}, \tilde{\beta})]

--- a/pyhawkes/internals/continuous_time_helpers.pyx
+++ b/pyhawkes/internals/continuous_time_helpers.pyx
@@ -91,8 +91,8 @@ cpdef ct_resample_Z_logistic_normal_serial(
                     break
 
         if Z[n] == -2:
-            print "Failed!"
-            print acc
+            print("Failed!")
+            print(acc)
 
 cpdef ct_resample_Z_logistic_normal(
     double[::1] S, long[::1] C, long[::1] Z, double dt_max,

--- a/pyhawkes/internals/distributions.py
+++ b/pyhawkes/internals/distributions.py
@@ -11,7 +11,7 @@ class Discrete(object):
         self.D = p.size
 
     def _is_one_hot(self, x):
-        return x.shape == (self.D,) and x.dtype == np.int and x.sum() == 1
+        return x.shape == (self.D,) and np.issubdtype(x.dtype, np.integer) and x.sum() == 1
 
     def _isindex(self, x):
         return isinstance(x, int) and x >= 0 and x < self.D
@@ -126,7 +126,7 @@ class Gamma:
         return psi(self.alpha) - np.log(self.beta)
 
     def negentropy(self, E_ln_lambda=None, E_lambda=None, E_beta=None, E_ln_beta=None):
-        """
+        r"""
         Compute the entropy of the gamma distribution.
 
         :param E_ln_lambda: If given, use this in place of expectation wrt alpha and beta

--- a/pyhawkes/internals/impulses.py
+++ b/pyhawkes/internals/impulses.py
@@ -122,7 +122,7 @@ class DirichletImpulseResponses(GibbsSampling, MeanField, MeanFieldSVI):
         self.mf_update_gamma(data, minibatchfrac=minibatchfrac, stepsize=stepsize)
 
     def get_vlb(self):
-        """
+        r"""
         Variational lower bound for \lambda_k^0
         E[LN p(g | \gamma)] -
         E[LN q(g | \tilde{\gamma})]
@@ -296,7 +296,7 @@ class SBMDirichletImpulseResponses(GibbsSampling):
         self.mf_update_gamma(EZ)
 
     def get_vlb(self):
-        """
+        r"""
         Variational lower bound for \lambda_k^0
         E[LN p(g | \gamma)] -
         E[LN q(g | \tilde{\gamma})]

--- a/pyhawkes/internals/network.py
+++ b/pyhawkes/internals/network.py
@@ -96,7 +96,7 @@ class _StochasticBlockModelBase(BayesianDistribution):
 
 
         if c is not None:
-            assert isinstance(c, np.ndarray) and c.shape == (K,) and c.dtype == np.int \
+            assert isinstance(c, np.ndarray) and c.shape == (K,) and np.issubdtype(c.dtype, np.integer) \
                    and np.amin(c) >= 0 and np.amax(c) <= self.C-1, \
                 "c must be a length K-vector of block assignments"
             self.c = c.copy()
@@ -257,7 +257,7 @@ class GibbsSBM(_StochasticBlockModelBase, GibbsSampling):
 
             # Likelihood from network
             for ck in range(self.C):
-                c_temp = self.c.copy().astype(np.int)
+                c_temp = self.c.copy().astype(np.int64)
                 c_temp[k] = ck
 
                 # p(A[k,k'] | c)
@@ -725,7 +725,7 @@ class MeanFieldSBM(_StochasticBlockModelBase, MeanField, MeanFieldSVI):
         self.p = np.random.beta(self.mf_tau1, self.mf_tau0)
         self.v = np.random.gamma(self.mf_alpha, 1.0/self.mf_beta)
 
-        self.c = np.zeros(self.K, dtype=np.int)
+        self.c = np.zeros(self.K, dtype=np.int64)
         for k in range(self.K):
             self.c[k] = int(np.random.choice(self.C, p=self.mf_m[k,:]))
 
@@ -867,7 +867,7 @@ class StochasticBlockModelFixedSparsity(StochasticBlockModel):
         self.m = np.random.dirichlet(self.mf_pi)
         self.v = np.random.gamma(self.mf_alpha, 1.0/self.mf_beta)
 
-        self.c = np.zeros(self.K, dtype=np.int)
+        self.c = np.zeros(self.K, dtype=np.int64)
         for k in range(self.K):
             self.c[k] = int(np.random.choice(self.C, p=self.mf_m[k,:]))
 
@@ -882,7 +882,7 @@ class ErdosRenyiModel(StochasticBlockModel):
                  v=None, alpha=1.0, beta=1.0,
                  kappa=1.0):
         C = 1
-        c = np.zeros(K, dtype=np.int)
+        c = np.zeros(K, dtype=np.int64)
         super(ErdosRenyiModel, self).__init__(K, C, c=c,
                                               p=p, tau0=tau0, tau1=tau1,
                                               v=v, alpha=alpha, beta=beta,

--- a/pyhawkes/internals/parents.py
+++ b/pyhawkes/internals/parents.py
@@ -283,7 +283,7 @@ class DiscreteTimeParents(GibbsSampling, MeanField):
 
     ### Mean Field
     def expected_log_likelihood(self,x):
-        """
+        r"""
         Compute the expected log likelihood of the data
         This is actually a bit tricky because we can't simply compute
         E[log \lambda_{t,k}] = E[log(\lambda_0 + \sum_{k,b} W_k g_{kb})]
@@ -359,7 +359,7 @@ class DiscreteTimeParents(GibbsSampling, MeanField):
         K, B = self.K, self.B
 
         for k2, (Sk, Fk, Tk, EZk) in enumerate(zip(self.Ss, self.Fs, self.Ts, self.EZ)):
-            Sk = Sk.astype(np.float)
+            Sk = Sk.astype(float)
             # Compute the normalized probability vector for the background rate and
             # each of the basis functions for every other process
             p0  = np.exp(bias_model.expected_log_lambda0()[k2])     # scalar
@@ -425,7 +425,7 @@ class DiscreteTimeParents(GibbsSampling, MeanField):
         return vlb
 
     def get_vlb_python(self):
-        """
+        r"""
         E_q[\ln p(z | \lambda)] - E_q[\ln q(z)]
         :return:
         """
@@ -452,7 +452,7 @@ class DiscreteTimeParents(GibbsSampling, MeanField):
         # The factorial of z cancels with the first term
         # The factorial of s is const wrt z
         for k, (EZk, Sk) in enumerate(zip(self.EZ, self.Ss)):
-            ln_u0 = np.log(EZk[:,0] / Sk.astype(np.float))
+            ln_u0 = np.log(EZk[:,0] / Sk.astype(float))
             ln_u0 = np.nan_to_num(ln_u0)
             vlb += (-EZk[:,0] * ln_u0).sum()
 
@@ -474,7 +474,7 @@ class DiscreteTimeParents(GibbsSampling, MeanField):
 
 
             # Second term
-            ln_u = np.log(EZk[:,1:] / Sk[:,None].astype(np.float))
+            ln_u = np.log(EZk[:,1:] / Sk[:, None].astype(float))
             ln_u = np.nan_to_num(ln_u)
             vlb += (-EZk[:,1:] * ln_u).sum()
         return vlb
@@ -497,7 +497,8 @@ class ContinuousTimeParents(GibbsSampling):
         self.model = model
 
         assert S.ndim == 1 and S.shape == C.shape
-        assert C.dtype == np.int and (len(C) == 0 or (C.min() >= 0 and C.max() < K))
+        assert np.issubdtype(C.dtype, np.integer) and \
+            (len(C) == 0 or (C.min() >= 0 and C.max() < K))
         self.S = S
         self.C = C
         self.T = T
@@ -507,7 +508,7 @@ class ContinuousTimeParents(GibbsSampling):
         self.dt_max = dt_max
 
         # Initialize parent arrays for Gibbs sampling
-        self.Z = -1 * np.ones((self.N,), dtype=np.int)
+        self.Z = -1 * np.ones((self.N,), dtype=np.int64)
         self.bkgd_ss = self.Ns.copy()
         self.weight_ss = np.zeros((self.K, self.K))
         self.imp_ss = np.zeros((self.K, self.K))

--- a/pyhawkes/models.py
+++ b/pyhawkes/models.py
@@ -157,7 +157,7 @@ class DiscreteTimeStandardHawkesModel(object):
                   and each process.
         """
         assert isinstance(S, np.ndarray) and S.ndim == 2 and S.shape[1] == self.K \
-               and np.amin(S) >= 0 and S.dtype == np.int, \
+               and np.amin(S) >= 0 and np.issubdtype(S.dtype, np.integer), \
                "Data must be a TxK array of event counts"
 
         T = S.shape[0]
@@ -208,7 +208,7 @@ class DiscreteTimeStandardHawkesModel(object):
             return False
 
     def copy_sample(self):
-        """
+        r"""
         Return a copy of the parameters of the model
         :return: The parameters of the model (A,W,\lambda_0, \beta)
         """
@@ -719,7 +719,7 @@ class _DiscreteTimeNetworkHawkesModelBase(object):
                   and each process.
         """
         assert isinstance(S, np.ndarray) and S.ndim == 2 and S.shape[1] == self.K \
-               and np.amin(S) >= 0 and S.dtype == np.int, \
+               and np.amin(S) >= 0 and np.issubdtype(S.dtype, np.integer), \
                "Data must be a TxK array of event counts"
 
         T = S.shape[0]
@@ -771,7 +771,7 @@ class _DiscreteTimeNetworkHawkesModelBase(object):
         return maxeig < 1.0
 
     def copy_sample(self):
-        """
+        r"""
         Return a copy of the parameters of the model
         :return: The parameters of the model (A,W,\lambda_0, \beta)
         """
@@ -841,7 +841,7 @@ class _DiscreteTimeNetworkHawkesModelBase(object):
                 import pdb; pdb.set_trace()
 
         # Only keep the first T time bins
-        S = S[:T,:].astype(np.int)
+        S = S[:T,:].astype(np.int64, copy=False)
         R = R[:T,:]
 
         if keep:
@@ -1566,7 +1566,7 @@ class ContinuousTimeNetworkHawkesModel(ModelGibbsSampling):
         if len(S) > 0:
             assert isinstance(S, np.ndarray) and S.ndim == 1 \
                    and S.min() >= 0 and S.max() < T and \
-                   S.dtype == np.float, \
+                   np.issubdtype(S.dtype, np.floating), \
                    "S must be a N array of event times"
 
             # Make sure S is sorted
@@ -1575,7 +1575,7 @@ class ContinuousTimeNetworkHawkesModel(ModelGibbsSampling):
         if len(C) > 0:
             assert isinstance(C, np.ndarray) and C.shape == S.shape \
                    and C.min() >= 0 and C.max() < self.K and \
-                   C.dtype == np.int, \
+                   np.issubdtype(C.dtype, np.integer), \
                    "C must be a N array of parent indices"
 
         # Instantiate corresponding parent object
@@ -1626,7 +1626,7 @@ class ContinuousTimeNetworkHawkesModel(ModelGibbsSampling):
                 n_ch = len(s_ch)
 
                 S.append(s_ch)
-                C.append(c_ch * np.ones(n_ch, dtype=np.int))
+                C.append(c_ch * np.ones(n_ch, dtype=np.int64))
 
                 # Generate offspring from child spikes
                 for s in s_ch:
@@ -1640,7 +1640,7 @@ class ContinuousTimeNetworkHawkesModel(ModelGibbsSampling):
         for k in np.arange(K):
             N = np.random.poisson(lambda0[k]*T)
             S_bkgd = np.random.rand(N)*T
-            C_bkgd = k*np.ones(N, dtype=np.int)
+            C_bkgd = k*np.ones(N, dtype=np.int64)
             S.append(S_bkgd)
             C.append(C_bkgd)
 
@@ -1683,7 +1683,7 @@ class ContinuousTimeNetworkHawkesModel(ModelGibbsSampling):
             return False
 
     def copy_sample(self):
-        """
+        r"""
         Return a copy of the parameters of the model
         :return: The parameters of the model (A,W,\lambda_0, \beta)
         """

--- a/pyhawkes/standard_models.py
+++ b/pyhawkes/standard_models.py
@@ -44,7 +44,7 @@ class _NonlinearHawkesNodeBase(object):
 
     def add_data(self, F, S):
         T = F.shape[0]
-        assert S.shape == (T,) and S.dtype in (np.int, np.uint, np.uint32)
+        assert S.shape == (T,) and np.issubdtype(S.dtype, np.integer)
 
         if F.shape[1] == self.K * self.B:
             F = np.hstack([np.ones((T,)),  F])
@@ -281,7 +281,7 @@ class _NonlinearHawkesProcessBase(object):
                   and each process.
         """
         assert isinstance(S, np.ndarray) and S.ndim == 2 and S.shape[1] == self.K \
-               and np.amin(S) >= 0 and S.dtype == np.int, \
+               and np.amin(S) >= 0 and np.issubdtype(S.dtype, np.integer), \
                "Data must be a TxK array of event counts"
 
         T = S.shape[0]

--- a/pyhawkes/utils/basis.py
+++ b/pyhawkes/utils/basis.py
@@ -122,7 +122,7 @@ class CosineBasis(Basis):
         b = self.b                          # Offset in log time
         nlin = lambda t: np.log(a*t+b)      # Nonlinearity
         u_ir = nlin(np.arange(n_pts))       # Time in log time
-        ctrs = u_ir[np.floor(np.linspace(n_eye,(n_pts/2.0),n_cos)).astype(np.int)]
+        ctrs = u_ir[np.floor(np.linspace(n_eye, (n_pts/2.0), n_cos)).astype(np.int64)]
         if len(ctrs) == 1:
             w = ctrs/2
         else:

--- a/pyhawkes/utils/utils.py
+++ b/pyhawkes/utils/utils.py
@@ -40,7 +40,7 @@ def convert_continuous_to_discrete(S, C, dt, T_min, T_max):
         S_dt[:,k] = np.histogram(S[C==k], bins)[0]
 
     assert S_dt.sum() == len(S)
-    return S_dt.astype(np.int)
+    return S_dt.astype(np.int64)
 
 def get_unique_file_name(filedir, filename):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+  "setuptools>=61",
+  "wheel",
+  "Cython>=0.29",
+  "numpy"
+]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -2,15 +2,16 @@
 
 import os
 import warnings
-from distutils.core import setup
-from Cython.Build import cythonize
+
 import numpy as np
+from Cython.Build import cythonize
+from setuptools import setup
 
 extra_compile_args = []
 extra_link_args = []
 
 # Only compile with OpenMP if user asks for it
-USE_OPENMP = os.environ.get('USE_OPENMP', False)
+USE_OPENMP = os.environ.get('USE_OPENMP', '').lower() in ("1", "true", "yes", "on")
 if USE_OPENMP:
     extra_compile_args.append('-fopenmp')
     extra_link_args.append('-fopenmp')
@@ -21,10 +22,12 @@ else:
                   "using the GNU gcc and g++ compilers and then run "
                   "'export USE_OPENMP=True' before installing.")
 
-ext_modules = cythonize('**/*.pyx')
+ext_modules = cythonize('**/*.pyx', compiler_directives={"language_level": "3"})
 for e in ext_modules:
     e.extra_compile_args.extend(extra_compile_args)
     e.extra_link_args.extend(extra_link_args)
+    if np.get_include() not in e.include_dirs:
+        e.include_dirs.append(np.get_include())
 
 setup(name='pyhawkes',
       version='0.3.1',
@@ -35,6 +38,6 @@ setup(name='pyhawkes',
       ext_modules=ext_modules,
       install_requires=['numpy', 'scipy', 'matplotlib',
                         'joblib', 'scikit-learn', 'pybasicbayes'],
-      include_dirs=[np.get_include(),],
+      include_dirs=[np.get_include()],
       packages=['pyhawkes', 'pyhawkes.internals', 'pyhawkes.utils']
      )

--- a/test/cython_parallel_parent_test.py
+++ b/test/cython_parallel_parent_test.py
@@ -12,7 +12,7 @@ def test_parallel_parent_updates():
     T = 10000
     K = 100
     B = 3
-    S = np.random.poisson(2.0, size=((T,K))).astype(np.int)
+    S = np.random.poisson(2.0, size=((T,K))).astype(np.int64)
 
     EZ0 = np.zeros((T,K))
     EZ  = np.zeros((T,K,K,B))

--- a/test/geweke_ct_test.py
+++ b/test/geweke_ct_test.py
@@ -18,7 +18,7 @@ def test_geweke():
     dt = 1.0
     dt_max = 3.0
     # network_hypers = {'C': 1, 'p': 0.5, 'kappa': 3.0, 'alpha': 3.0, 'beta': 1.0/20.0}
-    network_hypers = {'c': np.zeros(K, dtype=np.int), 'p': 0.5, 'kappa': 10.0, 'v': 10*3.0}
+    network_hypers = {'c': np.zeros(K, dtype=np.int64), 'p': 0.5, 'kappa': 10.0, 'v': 10*3.0}
     bkgd_hypers = {"alpha": 1., "beta": 10.}
     model = ContinuousTimeNetworkHawkesModel(K=K, dt_max=dt_max,
                                              network_hypers=network_hypers)

--- a/test/geweke_ss_test.py
+++ b/test/geweke_ss_test.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     dt = 1.0
     dt_max = 3.0
     # network_hypers = {'C': 1, 'p': 0.5, 'kappa': 3.0, 'alpha': 3.0, 'beta': 1.0/20.0}
-    network_hypers = {'c': np.zeros(K, dtype=np.int), 'p': 0.5, 'kappa': 10.0, 'v': 10*3.0}
+    network_hypers = {'c': np.zeros(K, dtype=np.int64), 'p': 0.5, 'kappa': 10.0, 'v': 10*3.0}
     bkgd_hypers = {"alpha": 1., "beta": 10.}
     model = DiscreteTimeNetworkHawkesModelSpikeAndSlab(K=K, dt=dt, dt_max=dt_max,
                                                        weight_hypers={"parallel_resampling": False},

--- a/test/geweke_test.py
+++ b/test/geweke_test.py
@@ -14,7 +14,7 @@ if __name__ == "__main__":
     T = 50
     dt = 1.0
     dt_max = 3.0
-    network_hypers = {'c': np.array([0], dtype=np.int),
+    network_hypers = {'c': np.array([0], dtype=np.int64),
                       'p': 0.5, 'kappa': 3.0, 'v': 15.0}
     weight_hypers = {"kappa_0": 3.0, "nu_0": 15.0}
     model = DiscreteTimeNetworkHawkesModelGammaMixture(K=1, dt=dt, dt_max=dt_max,

--- a/test/test_model.py
+++ b/test/test_model.py
@@ -5,7 +5,7 @@ def test_compute_rate():
     K = 1
     T = 100
     dt = 1.0
-    network_hypers = {'c': np.zeros(K, dtype=np.int), 'p': 1.0, 'kappa': 10.0, 'v': 10*5.0}
+    network_hypers = {'c': np.zeros(K, dtype=np.int64), 'p': 1.0, 'kappa': 10.0, 'v': 10*5.0}
     true_model = DiscreteTimeNetworkHawkesModelSpikeAndSlab(K=K, dt=dt,
                                                             network_hypers=network_hypers)
     S,R = true_model.generate(T=T)
@@ -24,7 +24,7 @@ def test_generate_statistics():
     K = 1
     T = 100
     dt = 1.0
-    network_hypers = {'c': np.zeros(K, dtype=np.int), 'p': 1.0, 'kappa': 10.0, 'v': 10*5.0}
+    network_hypers = {'c': np.zeros(K, dtype=np.int64), 'p': 1.0, 'kappa': 10.0, 'v': 10*5.0}
     true_model = DiscreteTimeNetworkHawkesModelSpikeAndSlab(K=K, dt=dt,
                                                             network_hypers=network_hypers)
     S,R = true_model.generate(T=T)


### PR DESCRIPTION
## Summary
- switch the build configuration to setuptools, declare build requirements, and set Cython to language level 3
- replace deprecated NumPy scalar aliases with robust dtype handling across the core library, utilities, tests, and data helpers
- clean up remaining Python 3 incompatibilities such as raw docstrings and print statements

## Testing
- pytest *(fails: missing numpy/scipy because dependencies cannot be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbd4bf9908329b629ac0bc1d13403